### PR TITLE
feat: add dashboard and item flows

### DIFF
--- a/src/components/DashboardCard.tsx
+++ b/src/components/DashboardCard.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Card, CardContent, Typography, Box } from '@mui/material';
+import { styled } from '@mui/material/styles';
+
+interface DashboardCardProps {
+  title: string;
+  value: string | number;
+  icon?: React.ReactNode;
+}
+
+const StyledCard = styled(Card)(({ theme }) => ({
+  height: '100%',
+  padding: theme.spacing(2),
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  alignItems: 'flex-start',
+}));
+
+export default function DashboardCard({ title, value, icon }: DashboardCardProps) {
+  return (
+    <StyledCard>
+      <CardContent sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+        {icon && <Box sx={{ color: 'primary.main' }}>{icon}</Box>}
+        <Box>
+          <Typography variant="subtitle2" color="text.secondary">
+            {title}
+          </Typography>
+          <Typography variant="h5">{value}</Typography>
+        </Box>
+      </CardContent>
+    </StyledCard>
+  );
+}

--- a/src/components/FilterSidebar.tsx
+++ b/src/components/FilterSidebar.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Drawer, Box, Typography, FormGroup, FormControlLabel, Checkbox } from '@mui/material';
+import { styled } from '@mui/material/styles';
+
+interface FilterSidebarProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const SidebarContent = styled(Box)(({ theme }) => ({
+  width: 260,
+  padding: theme.spacing(3),
+}));
+
+export default function FilterSidebar({ open, onClose }: FilterSidebarProps) {
+  return (
+    <Drawer anchor="left" open={open} onClose={onClose} variant="temporary">
+      <SidebarContent>
+        <Typography variant="h6" gutterBottom>
+          Filters
+        </Typography>
+        <FormGroup>
+          <FormControlLabel control={<Checkbox />} label="Placeholder" />
+        </FormGroup>
+      </SidebarContent>
+    </Drawer>
+  );
+}

--- a/src/components/FolderSelector.tsx
+++ b/src/components/FolderSelector.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { FormControl, InputLabel, Select, MenuItem } from '@mui/material';
+
+export interface FolderSelectorProps {
+  options: string[];
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export default function FolderSelector({ options, value, onChange }: FolderSelectorProps) {
+  return (
+    <FormControl fullWidth>
+      <InputLabel id="folder-select-label">Folder</InputLabel>
+      <Select
+        labelId="folder-select-label"
+        label="Folder"
+        value={value}
+        onChange={e => onChange(e.target.value as string)}
+      >
+        {options.map(option => (
+          <MenuItem value={option} key={option}>
+            {option}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  );
+}

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import { Box, Button, Typography } from '@mui/material';
+import { styled } from '@mui/material/styles';
+
+interface ImageUploaderProps {
+  onChange: (file: File | null) => void;
+}
+
+const Preview = styled('img')(({ theme }) => ({
+  width: '100%',
+  height: 'auto',
+  borderRadius: theme.shape.borderRadius,
+  marginTop: theme.spacing(2),
+}));
+
+export default function ImageUploader({ onChange }: ImageUploaderProps) {
+  const [preview, setPreview] = useState<string | null>(null);
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0] || null;
+    onChange(file);
+    if (file) {
+      setPreview(URL.createObjectURL(file));
+    }
+    else {
+      setPreview(null);
+    }
+  };
+
+  return (
+    <Box>
+      <Button variant="outlined" component="label">
+        Upload Image
+        <input hidden type="file" accept="image/*" onChange={handleFileChange} />
+      </Button>
+      {preview
+        ? <Preview src={preview} alt="Preview" />
+        : (
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+              No image selected
+            </Typography>
+          )}
+    </Box>
+  );
+}

--- a/src/components/ItemDetailSection.tsx
+++ b/src/components/ItemDetailSection.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Card, CardContent, Typography } from '@mui/material';
+import { styled } from '@mui/material/styles';
+
+interface ItemDetailSectionProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+const SectionCard = styled(Card)(({ theme }) => ({
+  marginBottom: theme.spacing(2),
+}));
+
+export default function ItemDetailSection({ title, children }: ItemDetailSectionProps) {
+  return (
+    <SectionCard>
+      <CardContent>
+        <Typography variant="h6" gutterBottom>
+          {title}
+        </Typography>
+        {children}
+      </CardContent>
+    </SectionCard>
+  );
+}

--- a/src/components/ItemGrid.tsx
+++ b/src/components/ItemGrid.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import {
+  Grid,
+  List,
+  ListItem,
+  ListItemText,
+  Card,
+  CardActionArea,
+  CardMedia,
+  CardContent,
+  Typography,
+} from '@mui/material';
+import { styled } from '@mui/material/styles';
+
+export interface ItemGridItem {
+  id: string;
+  title: string;
+  cover?: string;
+}
+
+interface ItemGridProps {
+  items: ItemGridItem[];
+  view: 'grid' | 'list';
+  onSelect?: (item: ItemGridItem) => void;
+}
+
+const GridItemCard = styled(Card)(({ theme }) => ({
+  height: '100%',
+}));
+
+export default function ItemGrid({ items, view, onSelect }: ItemGridProps) {
+  if (view === 'list') {
+    return (
+      <List>
+        {items.map(item => (
+          <ListItem key={item.id} button onClick={() => onSelect?.(item)}>
+            <ListItemText primary={item.title} />
+          </ListItem>
+        ))}
+      </List>
+    );
+  }
+
+  return (
+    <Grid container spacing={2}>
+      {items.map(item => (
+        <Grid item xs={6} sm={4} md={3} key={item.id}>
+          <GridItemCard>
+            <CardActionArea onClick={() => onSelect?.(item)}>
+              {item.cover && (
+                <CardMedia component="img" image={item.cover} alt={item.title} height={140} />
+              )}
+              <CardContent>
+                <Typography variant="body2" noWrap>
+                  {item.title}
+                </Typography>
+              </CardContent>
+            </CardActionArea>
+          </GridItemCard>
+        </Grid>
+      ))}
+    </Grid>
+  );
+}

--- a/src/components/OtherVersionsCarousel.tsx
+++ b/src/components/OtherVersionsCarousel.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Box, Card, CardMedia, CardContent, Typography } from '@mui/material';
+import { styled } from '@mui/material/styles';
+
+export interface VersionItem {
+  id: string;
+  title: string;
+  cover?: string;
+}
+
+interface OtherVersionsCarouselProps {
+  versions: VersionItem[];
+  onSelect?: (item: VersionItem) => void;
+}
+
+const CarouselContainer = styled(Box)(({ theme }) => ({
+  'display': 'flex',
+  'overflowX': 'auto',
+  'gap': theme.spacing(2),
+  'padding': theme.spacing(2, 0),
+  '& > *': {
+    flex: '0 0 auto',
+  },
+}));
+
+const VersionCard = styled(Card)(({ theme }) => ({
+  width: 120,
+}));
+
+export default function OtherVersionsCarousel({ versions, onSelect }: OtherVersionsCarouselProps) {
+  return (
+    <CarouselContainer>
+      {versions.map(version => (
+        <VersionCard key={version.id} onClick={() => onSelect?.(version)}>
+          {version.cover && <CardMedia component="img" height={140} image={version.cover} alt={version.title} />}
+          <CardContent>
+            <Typography variant="body2" noWrap>
+              {version.title}
+            </Typography>
+          </CardContent>
+        </VersionCard>
+      ))}
+    </CarouselContainer>
+  );
+}

--- a/src/components/TagSelector.tsx
+++ b/src/components/TagSelector.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Autocomplete, TextField } from '@mui/material';
+
+export interface TagSelectorProps {
+  options: string[];
+  value: string[];
+  onChange: (value: string[]) => void;
+}
+
+export default function TagSelector({ options, value, onChange }: TagSelectorProps) {
+  return (
+    <Autocomplete
+      multiple
+      options={options}
+      value={value}
+      onChange={(_, newValue) => onChange(newValue)}
+      renderInput={params => <TextField {...params} label="Tags" placeholder="Select tags" />}
+    />
+  );
+}

--- a/src/pages/AddItem.tsx
+++ b/src/pages/AddItem.tsx
@@ -1,0 +1,84 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  TextField,
+  Button,
+  Stepper,
+  Step,
+  StepLabel,
+  MenuItem,
+} from '@mui/material';
+import { styled } from '@mui/material/styles';
+import TagSelector from '../components/TagSelector';
+import FolderSelector from '../components/FolderSelector';
+import ImageUploader from '../components/ImageUploader';
+
+const FormContainer = styled(Box)(({ theme }) => ({
+  display: 'grid',
+  gap: theme.spacing(2),
+}));
+
+const tagOptions = ['Rock', 'Jazz', 'Pop'];
+const folderOptions = ['Default', 'Wishlist'];
+
+export default function AddItem() {
+  const [step, setStep] = useState(0);
+  const [tags, setTags] = useState<string[]>([]);
+  const [folder, setFolder] = useState('');
+
+  return (
+    <Box p={2} pb={8}>
+      <Stepper activeStep={step} sx={{ mb: 2 }}>
+        <Step>
+          <StepLabel>Scan or Search</StepLabel>
+        </Step>
+        <Step>
+          <StepLabel>Metadata</StepLabel>
+        </Step>
+      </Stepper>
+
+      {step === 0 && (
+        <Box>
+          <TextField fullWidth label="Search or Scan" sx={{ mb: 2 }} />
+          <Button variant="contained" onClick={() => setStep(1)}>
+            Next
+          </Button>
+        </Box>
+      )}
+
+      {step === 1 && (
+        <FormContainer>
+          <TextField label="Title" fullWidth />
+          <TextField label="Artist" fullWidth />
+          <TextField label="Release Date" type="date" InputLabelProps={{ shrink: true }} fullWidth />
+          <TextField label="Condition" select fullWidth>
+            <MenuItem value="New">New</MenuItem>
+            <MenuItem value="Used">Used</MenuItem>
+          </TextField>
+          <TagSelector options={tagOptions} value={tags} onChange={setTags} />
+          <FolderSelector options={folderOptions} value={folder} onChange={setFolder} />
+          <ImageUploader onChange={() => {}} />
+        </FormContainer>
+      )}
+
+      {step === 1 && (
+        <Box
+          sx={{
+            position: { xs: 'fixed', md: 'static' },
+            bottom: { xs: 0, md: 'auto' },
+            left: 0,
+            right: 0,
+            p: 2,
+            bgcolor: 'background.paper',
+            borderTop: { xs: '1px solid', md: 'none' },
+            borderColor: 'divider',
+          }}
+        >
+          <Button variant="contained" fullWidth>
+            Submit
+          </Button>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,0 +1,175 @@
+import React, { useRef, useState, useEffect } from 'react';
+import {
+  Box,
+  Grid,
+  TextField,
+  Typography,
+  ToggleButton,
+  ToggleButtonGroup,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+} from '@mui/material';
+import { styled } from '@mui/material/styles';
+import DashboardCard from '../components/DashboardCard';
+import ItemGrid, { ItemGridItem } from '../components/ItemGrid';
+import FilterSidebar from '../components/FilterSidebar';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  CartesianGrid,
+  Tooltip,
+  PieChart,
+  Pie,
+  Cell,
+  ResponsiveContainer,
+} from 'recharts';
+
+const ChartContainer = styled(Box)(({ theme }) => ({
+  backgroundColor: theme.palette.background.paper,
+  borderRadius: theme.shape.borderRadius,
+  padding: theme.spacing(2),
+  height: 300,
+}));
+
+const stats = [
+  { title: 'Total Items', value: 128 },
+  { title: 'Estimated Value', value: '$3,200' },
+  { title: 'Recent Additions', value: 5 },
+];
+
+const acquisitionData = [
+  { month: 'Jan', items: 2 },
+  { month: 'Feb', items: 4 },
+  { month: 'Mar', items: 3 },
+  { month: 'Apr', items: 5 },
+  { month: 'May', items: 1 },
+];
+
+const genreData = [
+  { name: 'Rock', value: 40 },
+  { name: 'Jazz', value: 25 },
+  { name: 'Pop', value: 20 },
+  { name: 'Other', value: 15 },
+];
+
+const COLORS = ['#8884d8', '#82ca9d', '#ffc658', '#ff8042'];
+
+const recentItems: ItemGridItem[] = [
+  { id: '1', title: 'The Wall' },
+  { id: '2', title: 'Kind of Blue' },
+  { id: '3', title: 'Abbey Road' },
+  { id: '4', title: 'Thriller' },
+];
+
+export default function Dashboard() {
+  const searchRef = useRef<HTMLInputElement>(null);
+  const [view, setView] = useState<'grid' | 'list'>('grid');
+  const [quickEditOpen, setQuickEditOpen] = useState(false);
+  const [selected, setSelected] = useState<ItemGridItem | null>(null);
+  const [filterOpen, setFilterOpen] = useState(false);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === '/' && document.activeElement !== searchRef.current) {
+        e.preventDefault();
+        searchRef.current?.focus();
+      }
+      if (e.key.toLowerCase() === 'e') {
+        setQuickEditOpen(true);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
+  return (
+    <Box p={2}>
+      <FilterSidebar open={filterOpen} onClose={() => setFilterOpen(false)} />
+      <Grid container spacing={2} alignItems="center" mb={2}>
+        <Grid item xs={12} sm={6} md={4}>
+          <TextField fullWidth inputRef={searchRef} label="Search" />
+        </Grid>
+        <Grid item xs={12} sm={6} md={8}>
+          <Box display="flex" justifyContent="flex-end" gap={1}>
+            <ToggleButtonGroup
+              value={view}
+              exclusive
+              onChange={(_, val) => val && setView(val)}
+              size="small"
+            >
+              <ToggleButton value="grid">Grid</ToggleButton>
+              <ToggleButton value="list">List</ToggleButton>
+            </ToggleButtonGroup>
+            <Button variant="outlined" onClick={() => setFilterOpen(true)}>
+              Filters
+            </Button>
+          </Box>
+        </Grid>
+      </Grid>
+
+      <Grid container spacing={2}>
+        {stats.map(stat => (
+          <Grid item xs={12} sm={4} key={stat.title}>
+            <DashboardCard title={stat.title} value={stat.value} />
+          </Grid>
+        ))}
+      </Grid>
+
+      <Grid container spacing={2} mt={1}>
+        <Grid item xs={12} md={6}>
+          <ChartContainer>
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={acquisitionData}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="month" />
+                <Tooltip />
+                <Line type="monotone" dataKey="items" stroke="#8884d8" strokeWidth={2} />
+              </LineChart>
+            </ResponsiveContainer>
+          </ChartContainer>
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <ChartContainer>
+            <ResponsiveContainer width="100%" height="100%">
+              <PieChart>
+                <Pie data={genreData} dataKey="value" nameKey="name" outerRadius={80} label>
+                  {genreData.map((_, index) => (
+                    <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                  ))}
+                </Pie>
+                <Tooltip />
+              </PieChart>
+            </ResponsiveContainer>
+          </ChartContainer>
+        </Grid>
+      </Grid>
+
+      <Box mt={4}>
+        <Typography variant="h6" mb={2}>
+          Recently Added
+        </Typography>
+        <ItemGrid
+          items={recentItems}
+          view={view}
+          onSelect={(item) => {
+            setSelected(item);
+          }}
+        />
+      </Box>
+
+      <Dialog open={quickEditOpen} onClose={() => setQuickEditOpen(false)} fullWidth maxWidth="sm">
+        <DialogTitle>Quick Edit</DialogTitle>
+        <DialogContent>
+          {selected ? <Typography>{selected.title}</Typography> : <Typography>No item selected</Typography>}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setQuickEditOpen(false)}>Close</Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/src/pages/ItemDetail.tsx
+++ b/src/pages/ItemDetail.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import {
+  Box,
+  Grid,
+  Typography,
+  Button,
+  Stack,
+  Fab,
+} from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+import { styled, useTheme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import ItemDetailSection from '../components/ItemDetailSection';
+import OtherVersionsCarousel, { VersionItem } from '../components/OtherVersionsCarousel';
+
+const CoverImage = styled('img')(({ theme }) => ({
+  width: '100%',
+  borderRadius: theme.shape.borderRadius,
+}));
+
+const item = {
+  title: 'The Wall',
+  artist: 'Pink Floyd',
+  releaseDate: '1979',
+  condition: 'Very Good',
+  notes: 'Double album',
+  cover: 'https://via.placeholder.com/300x300.png?text=Cover',
+};
+
+const otherVersions: VersionItem[] = [
+  { id: 'a', title: 'The Wall - CD' },
+  { id: 'b', title: 'The Wall - Deluxe' },
+  { id: 'c', title: 'The Wall - Remaster' },
+];
+
+export default function ItemDetail() {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+
+  return (
+    <Box p={2} pb={8}>
+      <Grid container spacing={2}>
+        <Grid item xs={12} md={5}>
+          <CoverImage src={item.cover} alt={item.title} />
+        </Grid>
+        <Grid item xs={12} md={7}>
+          <ItemDetailSection title="Metadata">
+            <Typography variant="h5" gutterBottom>
+              {item.title}
+            </Typography>
+            <Typography variant="subtitle1" color="text.secondary">
+              {item.artist}
+            </Typography>
+            <Typography variant="body2">
+              Release Date:
+              {' '}
+              {item.releaseDate}
+            </Typography>
+            <Typography variant="body2">
+              Condition:
+              {' '}
+              {item.condition}
+            </Typography>
+          </ItemDetailSection>
+          <ItemDetailSection title="Notes">
+            <Typography variant="body2">{item.notes}</Typography>
+          </ItemDetailSection>
+          <Stack direction="row" spacing={2} mt={2}>
+            <Button variant="contained">Edit</Button>
+            <Button variant="outlined">Duplicate</Button>
+            <Button variant="outlined">Mark Sold</Button>
+          </Stack>
+        </Grid>
+      </Grid>
+      <Box mt={4}>
+        <Typography variant="h6" mb={2}>
+          Other Versions
+        </Typography>
+        <OtherVersionsCarousel versions={otherVersions} />
+      </Box>
+      {isMobile && (
+        <Fab color="primary" sx={{ position: 'fixed', bottom: 16, right: 16 }} aria-label="edit">
+          <EditIcon />
+        </Fab>
+      )}
+    </Box>
+  );
+}

--- a/src/types/recharts.d.ts
+++ b/src/types/recharts.d.ts
@@ -1,0 +1,1 @@
+declare module 'recharts';


### PR DESCRIPTION
## Summary
- build responsive dashboard with stats, charts, and recent items
- add item detail view with quick actions and carousel
- add two-step add item workflow and supporting components

## Testing
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_688d9c691b588321ba558120cbbee4f8